### PR TITLE
bugfix: remove clear pass (https://github.com/lapce/lapce/issues/120)

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -394,42 +394,24 @@ impl Pipeline {
     ) {
         let fill_range = 0..(geometry.indices.len() as u32);
 
-        {
-            let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: None,
-                color_attachments: &[wgpu::RenderPassColorAttachment {
-                    view: &view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
-                        store: true,
-                    },
-                }],
-                depth_stencil_attachment: None,
-            });
-        }
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[wgpu::RenderPassColorAttachment {
+                view: msaa,
+                resolve_target: Some(&view),
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                    store: true,
+                },
+            }],
+            depth_stencil_attachment: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.bind_group, &[]);
+        pass.set_vertex_buffer(0, self.vertices.slice(..));
+        pass.set_index_buffer(self.indices.slice(..), wgpu::IndexFormat::Uint32);
 
-        {
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: None,
-                color_attachments: &[wgpu::RenderPassColorAttachment {
-                    view: msaa,
-                    resolve_target: Some(&view),
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: true,
-                    },
-                }],
-                depth_stencil_attachment: None,
-            });
-
-            pass.set_pipeline(&self.pipeline);
-            pass.set_bind_group(0, &self.bind_group, &[]);
-            pass.set_vertex_buffer(0, self.vertices.slice(..));
-            pass.set_index_buffer(self.indices.slice(..), wgpu::IndexFormat::Uint32);
-
-            pass.draw_indexed(fill_range.clone(), 0, 0..1);
-        }
+        pass.draw_indexed(fill_range.clone(), 0, 0..1);
     }
 }
 


### PR DESCRIPTION
this should resolve this problem: https://github.com/lapce/lapce/issues/120

why is the swapchain cleared on a seperate render pass. this might be a work around for the issue since I'm not really clear on the original change. there is a multisample example in wgpu that I was looking at and this seems consistent with that. 

![image](https://user-images.githubusercontent.com/854359/163659768-181998a5-30f3-4c57-8683-608e803edb40.png)
