### PR TITLE
Implement Image::size for WgpuImage

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -873,7 +873,8 @@ impl<'a> IntoBrush<WgpuRenderContext<'a>> for Brush {
 
 impl Image for WgpuImage {
     fn size(&self) -> piet::kurbo::Size {
-        todo!()
+        let (width, height) = self.img.dimensions();
+        piet::kurbo::Size::new(width as f64, height as f64)
     }
 }
 


### PR DESCRIPTION
I believe this implementation was forgotten. Technically not needed, since `img` is pub, but it avoids the confusion of trying to call `.size()` on `WgpuImage` and then crashing.