### PR TITLE
Adjust y_offset calculation to reference baseline

### DIFF
--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -149,12 +149,12 @@ impl WgpuTextLayout {
     pub fn y_offset(&self, height: f64) -> f64 {
         if let Some(line) = self.layout.get(0) {
             let metrics = line.metrics();
-            if metrics.cap_height > 0.0 {
-                (height - metrics.cap_height as f64) / 2.0
-                    - (metrics.ascent - metrics.cap_height) as f64
+            let letter_height = if metrics.cap_height > 0.0 {
+                metrics.cap_height
             } else {
-                (height - metrics.ascent as f64) / 2.0
-            }
+                metrics.ascent
+            };
+            (height - letter_height as f64) / 2.0 - (metrics.baseline - letter_height) as f64
         } else {
             0.0
         }


### PR DESCRIPTION
From my understanding, the extra pixels above the top of the letters should be `baseline - cap_height` not `ascent - cap_height` since `baseline` typically refers to the render position of the bottoms of the letters.

Also, it looks like we fall back to ascent if the cap_height doesn't exist, but I think it still makes sense to subtract the extra top pixels in this case.

Feel free to let me know if I'm misunderstanding anything here since this is based mostly on my interpretation of the code and general font rendering terminology.

For reference, here are the values for `Consolas`:
```
LineMetrics { ascent: 14.0, descent: 4.0, cap_height: 9.0, leading: 0.0, baseline: 14.0, offset: 0.0, advance: 0.0, trailing_whitespace: 0.0 }
```